### PR TITLE
ignore lib type check

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,7 +4,7 @@
     "useDefineForClassFields": true,
     "lib": ["DOM", "DOM.Iterable", "ESNext"],
     "allowJs": false,
-    "skipLibCheck": false,
+    "skipLibCheck": true,
     "esModuleInterop": false,
     "allowSyntheticDefaultImports": true,
     "strict": true,


### PR DESCRIPTION
## Proposed Changes
Address different ethereum global window definitions in web3modal and metamask/detect-provider packages

## Implementation
Skip type checking inside the library.

Note:
Please note that this support sacrifices some of the accuracy of the type checking.